### PR TITLE
Include windows-curses in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ python = "^3.6.2"
 pyaes = "^1.6.1"
 kimg4 = "^0.1.1"
 Pygments = "^2.11.2"
+windows-curses = {version = "^2.3.1", platform = "win32"}
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.12.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,17 @@
 name = "k2l"
 version = "1.4.0"
 description = "Static MachO/ObjC Reverse Engineering Toolkit"
-readme = "README.md"
-
-packages = [
-    { include = "ktool", from="src" },
-    { include = "kmacho", from="src" },
-    { include = "kswift", from="src" },
-    { include = "katlib", from="src" },
-    { include = "kdsc", from="src" }
-]
-
 authors = ["cynder <kat@cynder.me>"]
+license = "MIT"
+repository = "https://github.com/cxnder/ktool"
+readme = "README.md"
+packages = [
+   { include = "ktool", from="src" },
+   { include = "kmacho", from="src" },
+   { include = "kswift", from="src" },
+   { include = "katlib", from="src" },
+   { include = "kdsc", from="src" }
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Fixes #43. The following changes add `windows-curses` to the dependency list, only being installed on Windows platforms.

This PR also adds the repository and license fields to package metadata. This is specially useful to document what license and repository the project comes from when looking at it using `pip show`