### PR TITLE
Migrate from deprecated pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ ktool = "ktool.ktool_script:main"
 [tool.poetry.dependencies]
 python = "^3.6.2"
 Pygments = "^2.11.2"
+packaging = ">=21.3"
 windows-curses = {version = "^2.3.1", platform = "win32"}
 
 [tool.poetry.dev-dependencies]

--- a/src/ktool/ktool_script.py
+++ b/src/ktool/ktool_script.py
@@ -25,12 +25,7 @@ from collections import namedtuple
 from enum import Enum
 from typing import Union
 
-try:
-    # noinspection PyProtectedMember
-    from pkg_resources import packaging
-except ImportError:
-    # noinspection PyProtectedMember
-    from pkg_resources._vendor import packaging
+import packaging
 
 import ktool
 from ktool_macho import LOAD_COMMAND

--- a/src/ktool/util.py
+++ b/src/ktool/util.py
@@ -24,7 +24,7 @@ import shutil
 from ktool_macho import Struct, FAT_CIGAM, FAT_MAGIC, MH_CIGAM, MH_CIGAM_64, MH_MAGIC, MH_MAGIC_64
 from ktool.exceptions import *
 
-import pkg_resources
+import importlib.metadata
 
 import lib0cyn.log as log
 
@@ -39,8 +39,8 @@ except:
     JsonLexer = None
 
 try:
-    KTOOL_VERSION = pkg_resources.get_distribution('k2l').version
-except pkg_resources.DistributionNotFound:
+    KTOOL_VERSION = importlib.metadata.version('k2l')
+except importlib.metadata.PackageNotFoundError:
     KTOOL_VERSION = '1.0.0'
 THREAD_COUNT = os.cpu_count() - 1
 


### PR DESCRIPTION
pkg_resources library is now [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html). This pull request is to use importlib and the packaging library instead.

Tested building and running on Kali with python 3.13.3 and running on macOS 15.5 with python 3.13.5.